### PR TITLE
Optimize IR expression data structures

### DIFF
--- a/fmm/src/ir/arithmetic_operation.rs
+++ b/fmm/src/ir/arithmetic_operation.rs
@@ -11,11 +11,14 @@ pub enum ArithmeticOperator {
 }
 
 #[derive(Clone, Debug, PartialEq)]
-pub struct ArithmeticOperation {
+pub struct ArithmeticOperation(Arc<ArithmeticOperationInner>);
+
+#[derive(Debug, PartialEq)]
+struct ArithmeticOperationInner {
     type_: types::Primitive,
     operator: ArithmeticOperator,
-    lhs: Arc<Expression>,
-    rhs: Arc<Expression>,
+    lhs: Expression,
+    rhs: Expression,
 }
 
 impl ArithmeticOperation {
@@ -25,27 +28,30 @@ impl ArithmeticOperation {
         lhs: impl Into<Expression>,
         rhs: impl Into<Expression>,
     ) -> Self {
-        Self {
-            type_,
-            operator,
-            lhs: Arc::new(lhs.into()),
-            rhs: Arc::new(rhs.into()),
-        }
+        Self(
+            ArithmeticOperationInner {
+                type_,
+                operator,
+                lhs: lhs.into(),
+                rhs: rhs.into(),
+            }
+            .into(),
+        )
     }
 
     pub fn type_(&self) -> types::Primitive {
-        self.type_
+        self.0.type_
     }
 
     pub fn operator(&self) -> ArithmeticOperator {
-        self.operator
+        self.0.operator
     }
 
     pub fn lhs(&self) -> &Expression {
-        &self.lhs
+        &self.0.lhs
     }
 
     pub fn rhs(&self) -> &Expression {
-        &self.rhs
+        &self.0.rhs
     }
 }

--- a/fmm/src/ir/bit_cast.rs
+++ b/fmm/src/ir/bit_cast.rs
@@ -2,10 +2,13 @@ use crate::{ir::Expression, types::Type};
 use std::sync::Arc;
 
 #[derive(Clone, Debug, PartialEq)]
-pub struct BitCast {
+pub struct BitCast(Arc<BitCastInner>);
+
+#[derive(Clone, Debug, PartialEq)]
+struct BitCastInner {
     from: Type,
     to: Type,
-    expression: Arc<Expression>,
+    expression: Expression,
 }
 
 impl BitCast {
@@ -14,22 +17,25 @@ impl BitCast {
         to: impl Into<Type>,
         expression: impl Into<Expression>,
     ) -> Self {
-        Self {
-            from: from.into(),
-            to: to.into(),
-            expression: expression.into().into(),
-        }
+        Self(
+            BitCastInner {
+                from: from.into(),
+                to: to.into(),
+                expression: expression.into(),
+            }
+            .into(),
+        )
     }
 
     pub fn from(&self) -> &Type {
-        &self.from
+        &self.0.from
     }
 
     pub fn to(&self) -> &Type {
-        &self.to
+        &self.0.to
     }
 
     pub fn expression(&self) -> &Expression {
-        &self.expression
+        &self.0.expression
     }
 }

--- a/fmm/src/ir/bitwise_not_operation.rs
+++ b/fmm/src/ir/bitwise_not_operation.rs
@@ -3,24 +3,30 @@ use crate::types;
 use std::sync::Arc;
 
 #[derive(Clone, Debug, PartialEq)]
-pub struct BitwiseNotOperation {
+pub struct BitwiseNotOperation(Arc<BitwiseNotOperationInner>);
+
+#[derive(Clone, Debug, PartialEq)]
+struct BitwiseNotOperationInner {
     type_: types::Primitive,
-    value: Arc<Expression>,
+    value: Expression,
 }
 
 impl BitwiseNotOperation {
     pub fn new(type_: types::Primitive, value: impl Into<Expression>) -> Self {
-        Self {
-            type_,
-            value: Arc::new(value.into()),
-        }
+        Self(
+            BitwiseNotOperationInner {
+                type_,
+                value: value.into(),
+            }
+            .into(),
+        )
     }
 
     pub fn type_(&self) -> types::Primitive {
-        self.type_
+        self.0.type_
     }
 
     pub fn value(&self) -> &Expression {
-        &self.value
+        &self.0.value
     }
 }

--- a/fmm/src/ir/bitwise_operation.rs
+++ b/fmm/src/ir/bitwise_operation.rs
@@ -12,11 +12,14 @@ pub enum BitwiseOperator {
 }
 
 #[derive(Clone, Debug, PartialEq)]
-pub struct BitwiseOperation {
+pub struct BitwiseOperation(Arc<BitwiseOperationInner>);
+
+#[derive(Clone, Debug, PartialEq)]
+struct BitwiseOperationInner {
     type_: types::Primitive,
     operator: BitwiseOperator,
-    lhs: Arc<Expression>,
-    rhs: Arc<Expression>,
+    lhs: Expression,
+    rhs: Expression,
 }
 
 impl BitwiseOperation {
@@ -26,27 +29,30 @@ impl BitwiseOperation {
         lhs: impl Into<Expression>,
         rhs: impl Into<Expression>,
     ) -> Self {
-        Self {
-            type_,
-            operator,
-            lhs: Arc::new(lhs.into()),
-            rhs: Arc::new(rhs.into()),
-        }
+        Self(
+            BitwiseOperationInner {
+                type_,
+                operator,
+                lhs: lhs.into(),
+                rhs: rhs.into(),
+            }
+            .into(),
+        )
     }
 
     pub fn type_(&self) -> types::Primitive {
-        self.type_
+        self.0.type_
     }
 
     pub fn operator(&self) -> BitwiseOperator {
-        self.operator
+        self.0.operator
     }
 
     pub fn lhs(&self) -> &Expression {
-        &self.lhs
+        &self.0.lhs
     }
 
     pub fn rhs(&self) -> &Expression {
-        &self.rhs
+        &self.0.rhs
     }
 }

--- a/fmm/src/ir/comparison_operation.rs
+++ b/fmm/src/ir/comparison_operation.rs
@@ -13,11 +13,14 @@ pub enum ComparisonOperator {
 }
 
 #[derive(Clone, Debug, PartialEq)]
-pub struct ComparisonOperation {
+pub struct ComparisonOperation(Arc<ComparisonOperationInner>);
+
+#[derive(Clone, Debug, PartialEq)]
+struct ComparisonOperationInner {
     type_: types::Primitive,
     operator: ComparisonOperator,
-    lhs: Arc<Expression>,
-    rhs: Arc<Expression>,
+    lhs: Expression,
+    rhs: Expression,
 }
 
 impl ComparisonOperation {
@@ -29,27 +32,30 @@ impl ComparisonOperation {
         lhs: impl Into<Expression>,
         rhs: impl Into<Expression>,
     ) -> Self {
-        Self {
-            type_,
-            operator,
-            lhs: Arc::new(lhs.into()),
-            rhs: Arc::new(rhs.into()),
-        }
+        Self(
+            ComparisonOperationInner {
+                type_,
+                operator,
+                lhs: (lhs.into()),
+                rhs: (rhs.into()),
+            }
+            .into(),
+        )
     }
 
     pub fn type_(&self) -> types::Primitive {
-        self.type_
+        self.0.type_
     }
 
     pub fn operator(&self) -> ComparisonOperator {
-        self.operator
+        self.0.operator
     }
 
     pub fn lhs(&self) -> &Expression {
-        &self.lhs
+        &self.0.lhs
     }
 
     pub fn rhs(&self) -> &Expression {
-        &self.rhs
+        &self.0.rhs
     }
 }

--- a/fmm/src/ir/expression.rs
+++ b/fmm/src/ir/expression.rs
@@ -114,3 +114,14 @@ impl From<Variable> for Expression {
         Self::Variable(variable)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::mem::size_of;
+
+    #[test]
+    fn size() {
+        assert!(size_of::<Expression>() <= 3 * size_of::<usize>());
+    }
+}

--- a/fmm/src/ir/pointer_address.rs
+++ b/fmm/src/ir/pointer_address.rs
@@ -21,8 +21,8 @@ impl PointerAddress {
         Self(
             PointerAddressInner {
                 type_,
-                pointer: pointer.into().into(),
-                offset: offset.into().into(),
+                pointer: pointer.into(),
+                offset: offset.into(),
             }
             .into(),
         )

--- a/fmm/src/ir/pointer_address.rs
+++ b/fmm/src/ir/pointer_address.rs
@@ -3,10 +3,13 @@ use crate::types;
 use std::sync::Arc;
 
 #[derive(Clone, Debug, PartialEq)]
-pub struct PointerAddress {
+pub struct PointerAddress(Arc<PointerAddressInner>);
+
+#[derive(Clone, Debug, PartialEq)]
+struct PointerAddressInner {
     type_: types::Pointer, // type of the pointer value
-    pointer: Arc<Expression>,
-    offset: Arc<Expression>,
+    pointer: Expression,
+    offset: Expression,
 }
 
 impl PointerAddress {
@@ -15,22 +18,25 @@ impl PointerAddress {
         pointer: impl Into<Expression>,
         offset: impl Into<Expression>,
     ) -> Self {
-        Self {
-            type_,
-            pointer: pointer.into().into(),
-            offset: offset.into().into(),
-        }
+        Self(
+            PointerAddressInner {
+                type_,
+                pointer: pointer.into().into(),
+                offset: offset.into().into(),
+            }
+            .into(),
+        )
     }
 
     pub fn type_(&self) -> &types::Pointer {
-        &self.type_
+        &self.0.type_
     }
 
     pub fn pointer(&self) -> &Expression {
-        &self.pointer
+        &self.0.pointer
     }
 
     pub fn offset(&self) -> &Expression {
-        &self.offset
+        &self.0.offset
     }
 }

--- a/fmm/src/ir/record.rs
+++ b/fmm/src/ir/record.rs
@@ -13,13 +13,7 @@ struct RecordInner {
 
 impl Record {
     pub fn new(type_: types::Record, fields: Vec<Expression>) -> Self {
-        Self(
-            RecordInner {
-                type_,
-                fields: fields.into(),
-            }
-            .into(),
-        )
+        Self(RecordInner { type_, fields }.into())
     }
 
     pub fn type_(&self) -> &types::Record {

--- a/fmm/src/ir/record.rs
+++ b/fmm/src/ir/record.rs
@@ -3,24 +3,30 @@ use crate::types;
 use std::sync::Arc;
 
 #[derive(Clone, Debug, PartialEq)]
-pub struct Record {
+pub struct Record(Arc<RecordInner>);
+
+#[derive(Clone, Debug, PartialEq)]
+struct RecordInner {
     type_: types::Record,
-    fields: Arc<Vec<Expression>>,
+    fields: Vec<Expression>,
 }
 
 impl Record {
     pub fn new(type_: types::Record, fields: Vec<Expression>) -> Self {
-        Self {
-            type_,
-            fields: fields.into(),
-        }
+        Self(
+            RecordInner {
+                type_,
+                fields: fields.into(),
+            }
+            .into(),
+        )
     }
 
     pub fn type_(&self) -> &types::Record {
-        &self.type_
+        &self.0.type_
     }
 
     pub fn fields(&self) -> &[Expression] {
-        &self.fields
+        &self.0.fields
     }
 }

--- a/fmm/src/ir/record_address.rs
+++ b/fmm/src/ir/record_address.rs
@@ -17,7 +17,7 @@ impl RecordAddress {
         Self(
             RecordAddressInner {
                 type_,
-                pointer: pointer.into().into(),
+                pointer: pointer.into(),
                 field_index,
             }
             .into(),

--- a/fmm/src/ir/record_address.rs
+++ b/fmm/src/ir/record_address.rs
@@ -3,30 +3,36 @@ use crate::types;
 use std::sync::Arc;
 
 #[derive(Clone, Debug, PartialEq)]
-pub struct RecordAddress {
+pub struct RecordAddress(Arc<RecordAddressInner>);
+
+#[derive(Clone, Debug, PartialEq)]
+struct RecordAddressInner {
     type_: types::Record,
-    pointer: Arc<Expression>, // pointer to record
+    pointer: Expression, // pointer to record
     field_index: usize,
 }
 
 impl RecordAddress {
     pub fn new(type_: types::Record, pointer: impl Into<Expression>, field_index: usize) -> Self {
-        Self {
-            type_,
-            pointer: pointer.into().into(),
-            field_index,
-        }
+        Self(
+            RecordAddressInner {
+                type_,
+                pointer: pointer.into().into(),
+                field_index,
+            }
+            .into(),
+        )
     }
 
     pub fn type_(&self) -> &types::Record {
-        &self.type_
+        &self.0.type_
     }
 
     pub fn pointer(&self) -> &Expression {
-        &self.pointer
+        &self.0.pointer
     }
 
     pub fn field_index(&self) -> usize {
-        self.field_index
+        self.0.field_index
     }
 }

--- a/fmm/src/ir/union.rs
+++ b/fmm/src/ir/union.rs
@@ -18,7 +18,7 @@ impl Union {
             UnionInner {
                 type_,
                 member_index,
-                member: member.into().into(),
+                member: member.into(),
             }
             .into(),
         )

--- a/fmm/src/ir/union.rs
+++ b/fmm/src/ir/union.rs
@@ -3,7 +3,10 @@ use crate::types;
 use std::sync::Arc;
 
 #[derive(Clone, Debug, PartialEq)]
-pub struct Union {
+pub struct Union(Arc<UnionInner>);
+
+#[derive(Clone, Debug, PartialEq)]
+struct UnionInner {
     type_: types::Union,
     member_index: usize,
     member: Arc<Expression>,
@@ -11,22 +14,25 @@ pub struct Union {
 
 impl Union {
     pub fn new(type_: types::Union, member_index: usize, member: impl Into<Expression>) -> Self {
-        Self {
-            type_,
-            member_index,
-            member: member.into().into(),
-        }
+        Self(
+            UnionInner {
+                type_,
+                member_index,
+                member: member.into().into(),
+            }
+            .into(),
+        )
     }
 
     pub fn type_(&self) -> &types::Union {
-        &self.type_
+        &self.0.type_
     }
 
     pub fn member_index(&self) -> usize {
-        self.member_index
+        self.0.member_index
     }
 
     pub fn member(&self) -> &Expression {
-        &self.member
+        &self.0.member
     }
 }

--- a/fmm/src/ir/union.rs
+++ b/fmm/src/ir/union.rs
@@ -9,7 +9,7 @@ pub struct Union(Arc<UnionInner>);
 struct UnionInner {
     type_: types::Union,
     member_index: usize,
-    member: Arc<Expression>,
+    member: Expression,
 }
 
 impl Union {

--- a/fmm/src/ir/union_address.rs
+++ b/fmm/src/ir/union_address.rs
@@ -3,30 +3,36 @@ use crate::types;
 use std::sync::Arc;
 
 #[derive(Clone, Debug, PartialEq)]
-pub struct UnionAddress {
+pub struct UnionAddress(Arc<UnionAddressInner>);
+
+#[derive(Clone, Debug, PartialEq)]
+struct UnionAddressInner {
     type_: types::Union,
-    pointer: Arc<Expression>, // pointer to union
+    pointer: Expression, // pointer to union
     member_index: usize,
 }
 
 impl UnionAddress {
     pub fn new(type_: types::Union, pointer: impl Into<Expression>, member_index: usize) -> Self {
-        Self {
-            type_,
-            pointer: pointer.into().into(),
-            member_index,
-        }
+        Self(
+            UnionAddressInner {
+                type_,
+                pointer: pointer.into().into(),
+                member_index,
+            }
+            .into(),
+        )
     }
 
     pub fn type_(&self) -> &types::Union {
-        &self.type_
+        &self.0.type_
     }
 
     pub fn pointer(&self) -> &Expression {
-        &self.pointer
+        &self.0.pointer
     }
 
     pub fn member_index(&self) -> usize {
-        self.member_index
+        self.0.member_index
     }
 }

--- a/fmm/src/ir/union_address.rs
+++ b/fmm/src/ir/union_address.rs
@@ -17,7 +17,7 @@ impl UnionAddress {
         Self(
             UnionAddressInner {
                 type_,
-                pointer: pointer.into().into(),
+                pointer: pointer.into(),
                 member_index,
             }
             .into(),

--- a/fmm/src/ir/variable.rs
+++ b/fmm/src/ir/variable.rs
@@ -1,11 +1,15 @@
+use std::sync::Arc;
+
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Variable {
-    name: String,
+    name: Arc<str>,
 }
 
 impl Variable {
     pub fn new(name: impl Into<String>) -> Self {
-        Self { name: name.into() }
+        Self {
+            name: name.into().into(),
+        }
     }
 
     pub fn name(&self) -> &str {


### PR DESCRIPTION
# Benchmark

- Application: the compiler of https://github.com/pen-lang/pen

```
> hyperfine '~/src/github.com/pen-lang/pen/target/release/pen compile-prelude --target aarch64-apple-darwin /Users/raviqqe/worktree/2384c198b563320e/examples/life-game/.pen/default/packages/pen_prelude/Map.pen /Users/raviqqe/worktree/2384c198b563320e/examples/life-game/.pen/default/objects/Map_eca1efc0cf2dc7fa.bc /Users/raviqqe/worktree/2384c198b563320e/examples/life-game/.pen/default/objects/Map_eca1efc0cf2dc7f' '~/worktree/2384c198b563320e/target/release/pen compile-prelude --target aarch64-apple-darwin /Users/raviqqe/worktree/2384c198b563320e/examples/life-game/.pen/default/packages/pen_prelude/Map.pen /Users/raviqqe/worktree/2384c198b563320e/examples/life-game/.pen/default/objects/Map_eca1efc0cf2dc7fa.bc /Users/raviqqe/worktree/2384c198b563320e/examples/life-game/.pen/default/objects/Map_eca1efc0cf2dc7f'
Benchmark 1: ~/src/github.com/pen-lang/pen/target/release/pen compile-prelude --target aarch64-apple-darwin /Users/raviqqe/worktree/2384c198b563320e/examples/life-game/.pen/default/packages/pen_prelude/Map.pen /Users/raviqqe/worktree/2384c198b563320e/examples/life-game/.pen/default/objects/Map_eca1efc0cf2dc7fa.bc /Users/raviqqe/worktree/2384c198b563320e/examples/life-game/.pen/default/objects/Map_eca1efc0cf2dc7f
  Time (mean ± σ):     208.0 ms ±   1.0 ms    [User: 195.5 ms, System: 10.4 ms]
  Range (min … max):   206.6 ms … 210.4 ms    14 runs

Benchmark 2: ~/worktree/2384c198b563320e/target/release/pen compile-prelude --target aarch64-apple-darwin /Users/raviqqe/worktree/2384c198b563320e/examples/life-game/.pen/default/packages/pen_prelude/Map.pen /Users/raviqqe/worktree/2384c198b563320e/examples/life-game/.pen/default/objects/Map_eca1efc0cf2dc7fa.bc /Users/raviqqe/worktree/2384c198b563320e/examples/life-game/.pen/default/objects/Map_eca1efc0cf2dc7f
  Time (mean ± σ):     200.4 ms ±   0.5 ms    [User: 188.8 ms, System: 9.3 ms]
  Range (min … max):   199.5 ms … 201.3 ms    14 runs

Summary
  '~/worktree/2384c198b563320e/target/release/pen compile-prelude --target aarch64-apple-darwin /Users/raviqqe/worktree/2384c198b563320e/examples/life-game/.pen/default/packages/pen_prelude/Map.pen /Users/raviqqe/worktree/2384c198b563320e/examples/life-game/.pen/default/objects/Map_eca1efc0cf2dc7fa.bc /Users/raviqqe/worktree/2384c198b563320e/examples/life-game/.pen/default/objects/Map_eca1efc0cf2dc7f' ran
    1.04 ± 0.01 times faster than '~/src/github.com/pen-lang/pen/target/release/pen compile-prelude --target aarch64-apple-darwin /Users/raviqqe/worktree/2384c198b563320e/examples/life-game/.pen/default/packages/pen_prelude/Map.pen /Users/raviqqe/worktree/2384c198b563320e/examples/life-game/.pen/default/objects/Map_eca1efc0cf2dc7fa.bc /Users/raviqqe/worktree/2384c198b563320e/examples/life-game/.pen/default/objects/Map_eca1efc0cf2dc7f'
```